### PR TITLE
fix bug where 'auto_pading' convers data to np.float64

### DIFF
--- a/mmskeleton/datasets/utils/skeleton.py
+++ b/mmskeleton/datasets/utils/skeleton.py
@@ -32,7 +32,7 @@ def auto_pading(data_numpy, size, random_pad=False):
     C, T, V, M = data_numpy.shape
     if T < size:
         begin = random.randint(0, size - T) if random_pad else 0
-        data_numpy_paded = np.zeros((C, size, V, M))
+        data_numpy_paded = np.zeros((C, size, V, M), dtype=data_numpy.dtype)
         data_numpy_paded[:, begin:begin + T, :, :] = data_numpy
         return data_numpy_paded
     else:


### PR DESCRIPTION
Function `auto_pading`, which is used for augmentation, creates a numpy array of default dtype, float64, when `T < size`.
This fixes the issue by using the original data dtype to create the new array.