### PR TITLE
fix windows mmskl_home with prefix `r`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def write_version_py():
 # TIME: {}
 __version__ = '{}'
 short_version = '{}'
-mmskl_home = '{}'
+mmskl_home = r'{}'
 """
     sha = get_hash()
     VERSION = SHORT_VERSION + '+' + sha


### PR DESCRIPTION
mmskl_home generated as a path `'C:\path\to\mmskeleton'` won't work without prefix `r` because some characters will be escape