### PR TITLE
Fix setup py: re-enable building of extensions and specify build dependencies as per PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "torch", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,8 @@ import platform
 import subprocess
 import time
 
-from setuptools import find_packages, setup, Extension, dist
+from setuptools import find_packages, setup, Extension
 from setuptools.command.install import install
-dist.Distribution().fetch_build_eggs(['Cython', 'numpy>=1.11.1', 'torch'])
 
 import numpy as np
 from Cython.Build import cythonize  # noqa: E402


### PR DESCRIPTION
Previously: https://github.com/open-mmlab/mmskeleton/issues/292

We should build extensions in setup.py. The problem is just one of combining Cython and CUDA building. The first commit in this PR does just that.

The second commit in this PR is to use PEP 518. See: https://medium.com/@grassfedcode/pep-517-and-518-in-plain-english-47208ca8b7a6