### PR TITLE
update to latest mmcv and fixed training

### DIFF
--- a/configs/mmdet/cascade_rcnn_r50_fpn_1x.py
+++ b/configs/mmdet/cascade_rcnn_r50_fpn_1x.py
@@ -1,159 +1,190 @@
+
 # model settings
-model = dict(type='CascadeRCNN',
-             num_stages=3,
-             pretrained='torchvision://resnet50',
-             backbone=dict(type='ResNet',
-                           depth=50,
-                           num_stages=4,
-                           out_indices=(0, 1, 2, 3),
-                           frozen_stages=1,
-                           style='pytorch'),
-             neck=dict(type='FPN',
-                       in_channels=[256, 512, 1024, 2048],
-                       out_channels=256,
-                       num_outs=5),
-             rpn_head=dict(type='RPNHead',
-                           in_channels=256,
-                           feat_channels=256,
-                           anchor_scales=[8],
-                           anchor_ratios=[0.5, 1.0, 2.0],
-                           anchor_strides=[4, 8, 16, 32, 64],
-                           target_means=[.0, .0, .0, .0],
-                           target_stds=[1.0, 1.0, 1.0, 1.0],
-                           loss_cls=dict(type='CrossEntropyLoss',
-                                         use_sigmoid=True,
-                                         loss_weight=1.0),
-                           loss_bbox=dict(type='SmoothL1Loss',
-                                          beta=1.0 / 9.0,
-                                          loss_weight=1.0)),
-             bbox_roi_extractor=dict(type='SingleRoIExtractor',
-                                     roi_layer=dict(type='RoIAlign',
-                                                    out_size=7,
-                                                    sample_num=2),
-                                     out_channels=256,
-                                     featmap_strides=[4, 8, 16, 32]),
-             bbox_head=[
-                 dict(type='SharedFCBBoxHead',
-                      num_fcs=2,
-                      in_channels=256,
-                      fc_out_channels=1024,
-                      roi_feat_size=7,
-                      num_classes=81,
-                      target_means=[0., 0., 0., 0.],
-                      target_stds=[0.1, 0.1, 0.2, 0.2],
-                      reg_class_agnostic=True,
-                      loss_cls=dict(type='CrossEntropyLoss',
-                                    use_sigmoid=False,
-                                    loss_weight=1.0),
-                      loss_bbox=dict(type='SmoothL1Loss',
-                                     beta=1.0,
-                                     loss_weight=1.0)),
-                 dict(type='SharedFCBBoxHead',
-                      num_fcs=2,
-                      in_channels=256,
-                      fc_out_channels=1024,
-                      roi_feat_size=7,
-                      num_classes=81,
-                      target_means=[0., 0., 0., 0.],
-                      target_stds=[0.05, 0.05, 0.1, 0.1],
-                      reg_class_agnostic=True,
-                      loss_cls=dict(type='CrossEntropyLoss',
-                                    use_sigmoid=False,
-                                    loss_weight=1.0),
-                      loss_bbox=dict(type='SmoothL1Loss',
-                                     beta=1.0,
-                                     loss_weight=1.0)),
-                 dict(type='SharedFCBBoxHead',
-                      num_fcs=2,
-                      in_channels=256,
-                      fc_out_channels=1024,
-                      roi_feat_size=7,
-                      num_classes=81,
-                      target_means=[0., 0., 0., 0.],
-                      target_stds=[0.033, 0.033, 0.067, 0.067],
-                      reg_class_agnostic=True,
-                      loss_cls=dict(type='CrossEntropyLoss',
-                                    use_sigmoid=False,
-                                    loss_weight=1.0),
-                      loss_bbox=dict(type='SmoothL1Loss',
-                                     beta=1.0,
-                                     loss_weight=1.0))
-             ])
-# model training and testing settings
-train_cfg = dict(rpn=dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.7,
-                                        neg_iou_thr=0.3,
-                                        min_pos_iou=0.3,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=256,
-                                       pos_fraction=0.5,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=False),
-                          allowed_border=0,
-                          pos_weight=-1,
-                          debug=False),
-                 rpn_proposal=dict(nms_across_levels=False,
-                                   nms_pre=2000,
-                                   nms_post=2000,
-                                   max_num=2000,
-                                   nms_thr=0.7,
-                                   min_bbox_size=0),
-                 rcnn=[
-                     dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.5,
-                                        neg_iou_thr=0.5,
-                                        min_pos_iou=0.5,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=512,
-                                       pos_fraction=0.25,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=True),
-                          pos_weight=-1,
-                          debug=False),
-                     dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.6,
-                                        neg_iou_thr=0.6,
-                                        min_pos_iou=0.6,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=512,
-                                       pos_fraction=0.25,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=True),
-                          pos_weight=-1,
-                          debug=False),
-                     dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.7,
-                                        neg_iou_thr=0.7,
-                                        min_pos_iou=0.7,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=512,
-                                       pos_fraction=0.25,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=True),
-                          pos_weight=-1,
-                          debug=False)
-                 ],
-                 stage_loss_weights=[1, 0.5, 0.25])
-test_cfg = dict(rpn=dict(nms_across_levels=False,
-                         nms_pre=1000,
-                         nms_post=1000,
-                         max_num=1000,
-                         nms_thr=0.7,
-                         min_bbox_size=0),
-                rcnn=dict(score_thr=0.05,
-                          nms=dict(type='nms', iou_thr=0.5),
-                          max_per_img=100),
-                keep_all_stages=False)
+model = dict(
+    type='CascadeRCNN',
+    pretrained='torchvision://resnet50',
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
+        norm_eval=True,
+        style='pytorch'),
+    neck=dict(
+        type='FPN',
+        in_channels=[256, 512, 1024, 2048],
+        out_channels=256,
+        num_outs=5),
+    rpn_head=dict(
+        type='RPNHead',
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(
+            type='AnchorGenerator',
+            scales=[8],
+            ratios=[0.5, 1.0, 2.0],
+            strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(
+            type='DeltaXYWHBBoxCoder',
+            target_means=[.0, .0, .0, .0],
+            target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type='SmoothL1Loss', beta=1.0 / 9.0, loss_weight=1.0)),
+    roi_head=dict(
+        type='CascadeRoIHead',
+        num_stages=3,
+        stage_loss_weights=[1, 0.5, 0.25],
+        bbox_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        bbox_head=[
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.1, 0.1, 0.2, 0.2]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.05, 0.05, 0.1, 0.1]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.033, 0.033, 0.067, 0.067]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0))
+        ]),
+    # model training and testing settings
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                match_low_quality=True,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='RandomSampler',
+                num=256,
+                pos_fraction=0.5,
+                neg_pos_ub=-1,
+                add_gt_as_proposals=False),
+            allowed_border=0,
+            pos_weight=-1,
+            debug=False),
+        rpn_proposal=dict(
+            nms_pre=2000,
+            max_per_img=2000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=[
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.5,
+                    neg_iou_thr=0.5,
+                    min_pos_iou=0.5,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.6,
+                    neg_iou_thr=0.6,
+                    min_pos_iou=0.6,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.7,
+                    neg_iou_thr=0.7,
+                    min_pos_iou=0.7,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False)
+        ]),
+    test_cfg=dict(
+        rpn=dict(
+            nms_pre=1000,
+            max_per_img=1000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=dict(
+            score_thr=0.05,
+            nms=dict(type='nms', iou_threshold=0.5),
+            max_per_img=100)))
+
+
 # dataset settings
 dataset_type = 'CocoDataset'
 data_root = 'data/coco/'
-img_norm_cfg = dict(mean=[123.675, 116.28, 103.53],
-                    std=[58.395, 57.12, 57.375],
-                    to_rgb=True)
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
@@ -166,42 +197,53 @@ train_pipeline = [
 ]
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='MultiScaleFlipAug',
-         img_scale=(1333, 800),
-         flip=False,
-         transforms=[
-             dict(type='Resize', keep_ratio=True),
-             dict(type='RandomFlip'),
-             dict(type='Normalize', **img_norm_cfg),
-             dict(type='Pad', size_divisor=32),
-             dict(type='ImageToTensor', keys=['img']),
-             dict(type='Collect', keys=['img']),
-         ])
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(1333, 800),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
 ]
 data = dict(
-    imgs_per_gpu=2,
+    samples_per_gpu=2,
     workers_per_gpu=2,
-    train=dict(type=dataset_type,
-               ann_file=data_root + 'annotations/instances_train2017.json',
-               img_prefix=data_root + 'train2017/',
-               pipeline=train_pipeline),
-    val=dict(type=dataset_type,
-             ann_file=data_root + 'annotations/instances_val2017.json',
-             img_prefix=data_root + 'val2017/',
-             pipeline=test_pipeline),
-    test=dict(type=dataset_type,
-              ann_file=data_root + 'annotations/instances_val2017.json',
-              img_prefix=data_root + 'val2017/',
-              pipeline=test_pipeline))
+    train=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/instances_train2017.json',
+        img_prefix=data_root + 'train2017/',
+        pipeline=train_pipeline),
+    val=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/instances_val2017.json',
+        img_prefix=data_root + 'val2017/',
+        pipeline=test_pipeline),
+    test=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/instances_val2017.json',
+        img_prefix=data_root + 'val2017/',
+        pipeline=test_pipeline))
+evaluation = dict(interval=1, metric='bbox')
+
+
 # optimizer
 optimizer = dict(type='SGD', lr=0.02, momentum=0.9, weight_decay=0.0001)
-optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
+optimizer_config = dict(grad_clip=None)
 # learning policy
-lr_config = dict(policy='step',
-                 warmup='linear',
-                 warmup_iters=500,
-                 warmup_ratio=1.0 / 3,
-                 step=[8, 11])
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=0.001,
+    step=[8, 11])
+runner = dict(type='EpochBasedRunner', max_epochs=12)
+
+
 checkpoint_config = dict(interval=1)
 # yapf:disable
 log_config = dict(
@@ -211,11 +253,10 @@ log_config = dict(
         # dict(type='TensorboardLoggerHook')
     ])
 # yapf:enable
-# runtime settings
-total_epochs = 12
+custom_hooks = [dict(type='NumClassCheckHook')]
+
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
-work_dir = './work_dirs/cascade_rcnn_r50_fpn_1x'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]

--- a/configs/mmdet/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e.py
+++ b/configs/mmdet/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e.py
@@ -1,240 +1,285 @@
-# model settings
-model = dict(type='HybridTaskCascade',
-             num_stages=3,
-             pretrained='open-mmlab://resnext101_64x4d',
-             interleaved=True,
-             mask_info_flow=True,
-             backbone=dict(type='ResNeXt',
-                           depth=101,
-                           groups=64,
-                           base_width=4,
-                           num_stages=4,
-                           out_indices=(0, 1, 2, 3),
-                           frozen_stages=1,
-                           style='pytorch',
-                           dcn=dict(modulated=False,
-                                    groups=64,
-                                    deformable_groups=1,
-                                    fallback_on_stride=False),
-                           stage_with_dcn=(False, True, True, True)),
-             neck=dict(type='FPN',
-                       in_channels=[256, 512, 1024, 2048],
-                       out_channels=256,
-                       num_outs=5),
-             rpn_head=dict(type='RPNHead',
-                           in_channels=256,
-                           feat_channels=256,
-                           anchor_scales=[8],
-                           anchor_ratios=[0.5, 1.0, 2.0],
-                           anchor_strides=[4, 8, 16, 32, 64],
-                           target_means=[.0, .0, .0, .0],
-                           target_stds=[1.0, 1.0, 1.0, 1.0],
-                           loss_cls=dict(type='CrossEntropyLoss',
-                                         use_sigmoid=True,
-                                         loss_weight=1.0),
-                           loss_bbox=dict(type='SmoothL1Loss',
-                                          beta=1.0 / 9.0,
-                                          loss_weight=1.0)),
-             bbox_roi_extractor=dict(type='SingleRoIExtractor',
-                                     roi_layer=dict(type='RoIAlign',
-                                                    out_size=7,
-                                                    sample_num=2),
-                                     out_channels=256,
-                                     featmap_strides=[4, 8, 16, 32]),
-             bbox_head=[
-                 dict(type='SharedFCBBoxHead',
-                      num_fcs=2,
-                      in_channels=256,
-                      fc_out_channels=1024,
-                      roi_feat_size=7,
-                      num_classes=81,
-                      target_means=[0., 0., 0., 0.],
-                      target_stds=[0.1, 0.1, 0.2, 0.2],
-                      reg_class_agnostic=True,
-                      loss_cls=dict(type='CrossEntropyLoss',
-                                    use_sigmoid=False,
-                                    loss_weight=1.0),
-                      loss_bbox=dict(type='SmoothL1Loss',
-                                     beta=1.0,
-                                     loss_weight=1.0)),
-                 dict(type='SharedFCBBoxHead',
-                      num_fcs=2,
-                      in_channels=256,
-                      fc_out_channels=1024,
-                      roi_feat_size=7,
-                      num_classes=81,
-                      target_means=[0., 0., 0., 0.],
-                      target_stds=[0.05, 0.05, 0.1, 0.1],
-                      reg_class_agnostic=True,
-                      loss_cls=dict(type='CrossEntropyLoss',
-                                    use_sigmoid=False,
-                                    loss_weight=1.0),
-                      loss_bbox=dict(type='SmoothL1Loss',
-                                     beta=1.0,
-                                     loss_weight=1.0)),
-                 dict(type='SharedFCBBoxHead',
-                      num_fcs=2,
-                      in_channels=256,
-                      fc_out_channels=1024,
-                      roi_feat_size=7,
-                      num_classes=81,
-                      target_means=[0., 0., 0., 0.],
-                      target_stds=[0.033, 0.033, 0.067, 0.067],
-                      reg_class_agnostic=True,
-                      loss_cls=dict(type='CrossEntropyLoss',
-                                    use_sigmoid=False,
-                                    loss_weight=1.0),
-                      loss_bbox=dict(type='SmoothL1Loss',
-                                     beta=1.0,
-                                     loss_weight=1.0))
-             ],
-             mask_roi_extractor=dict(type='SingleRoIExtractor',
-                                     roi_layer=dict(type='RoIAlign',
-                                                    out_size=14,
-                                                    sample_num=2),
-                                     out_channels=256,
-                                     featmap_strides=[4, 8, 16, 32]),
-             mask_head=dict(type='HTCMaskHead',
-                            num_convs=4,
-                            in_channels=256,
-                            conv_out_channels=256,
-                            num_classes=81,
-                            loss_mask=dict(type='CrossEntropyLoss',
-                                           use_mask=True,
-                                           loss_weight=1.0)),
-             semantic_roi_extractor=dict(type='SingleRoIExtractor',
-                                         roi_layer=dict(type='RoIAlign',
-                                                        out_size=14,
-                                                        sample_num=2),
-                                         out_channels=256,
-                                         featmap_strides=[8]),
-             semantic_head=dict(type='FusedSemanticHead',
-                                num_ins=5,
-                                fusion_level=1,
-                                num_convs=4,
-                                in_channels=256,
-                                conv_out_channels=256,
-                                num_classes=183,
-                                ignore_label=255,
-                                loss_weight=0.2))
-# model training and testing settings
-train_cfg = dict(rpn=dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.7,
-                                        neg_iou_thr=0.3,
-                                        min_pos_iou=0.3,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=256,
-                                       pos_fraction=0.5,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=False),
-                          allowed_border=0,
-                          pos_weight=-1,
-                          debug=False),
-                 rpn_proposal=dict(nms_across_levels=False,
-                                   nms_pre=2000,
-                                   nms_post=2000,
-                                   max_num=2000,
-                                   nms_thr=0.7,
-                                   min_bbox_size=0),
-                 rcnn=[
-                     dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.5,
-                                        neg_iou_thr=0.5,
-                                        min_pos_iou=0.5,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=512,
-                                       pos_fraction=0.25,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=True),
-                          mask_size=28,
-                          pos_weight=-1,
-                          debug=False),
-                     dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.6,
-                                        neg_iou_thr=0.6,
-                                        min_pos_iou=0.6,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=512,
-                                       pos_fraction=0.25,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=True),
-                          mask_size=28,
-                          pos_weight=-1,
-                          debug=False),
-                     dict(assigner=dict(type='MaxIoUAssigner',
-                                        pos_iou_thr=0.7,
-                                        neg_iou_thr=0.7,
-                                        min_pos_iou=0.7,
-                                        ignore_iof_thr=-1),
-                          sampler=dict(type='RandomSampler',
-                                       num=512,
-                                       pos_fraction=0.25,
-                                       neg_pos_ub=-1,
-                                       add_gt_as_proposals=True),
-                          mask_size=28,
-                          pos_weight=-1,
-                          debug=False)
-                 ],
-                 stage_loss_weights=[1, 0.5, 0.25])
-test_cfg = dict(rpn=dict(nms_across_levels=False,
-                         nms_pre=1000,
-                         nms_post=1000,
-                         max_num=1000,
-                         nms_thr=0.7,
-                         min_bbox_size=0),
-                rcnn=dict(score_thr=0.001,
-                          nms=dict(type='nms', iou_thr=0.5),
-                          max_per_img=100,
-                          mask_thr_binary=0.5),
-                keep_all_stages=False)
+model = dict(
+    type='HybridTaskCascade',
+    pretrained='open-mmlab://resnext101_64x4d',
+    backbone=dict(
+        type='ResNeXt',
+        depth=101,
+        groups=64,
+        base_width=4,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
+        norm_eval=True,
+        style='pytorch',
+        dcn=dict(type='DCN', deform_groups=1, fallback_on_stride=False),
+        stage_with_dcn=(False, True, True, True)),
+    neck=dict(
+        type='FPN',
+        in_channels=[256, 512, 1024, 2048],
+        out_channels=256,
+        num_outs=5),
+    rpn_head=dict(
+        type='RPNHead',
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(
+            type='AnchorGenerator',
+            scales=[8],
+            ratios=[0.5, 1.0, 2.0],
+            strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(
+            type='DeltaXYWHBBoxCoder',
+            target_means=[.0, .0, .0, .0],
+            target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type='SmoothL1Loss', beta=1.0 / 9.0, loss_weight=1.0)),
+
+    roi_head=dict(
+        type='HybridTaskCascadeRoIHead',
+        interleaved=True,
+        mask_info_flow=True,
+        num_stages=3,
+        stage_loss_weights=[1, 0.5, 0.25],
+        bbox_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        bbox_head=[
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.1, 0.1, 0.2, 0.2]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.05, 0.05, 0.1, 0.1]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0,
+                               loss_weight=1.0)),
+            dict(
+                type='Shared2FCBBoxHead',
+                in_channels=256,
+                fc_out_channels=1024,
+                roi_feat_size=7,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.033, 0.033, 0.067, 0.067]),
+                reg_class_agnostic=True,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0))
+        ],
+        mask_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=14, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        mask_head=[
+            dict(
+                type='HTCMaskHead',
+                with_conv_res=False,
+                num_convs=4,
+                in_channels=256,
+                conv_out_channels=256,
+                num_classes=80,
+                loss_mask=dict(
+                    type='CrossEntropyLoss', use_mask=True, loss_weight=1.0)),
+            dict(
+                type='HTCMaskHead',
+                num_convs=4,
+                in_channels=256,
+                conv_out_channels=256,
+                num_classes=80,
+                loss_mask=dict(
+                    type='CrossEntropyLoss', use_mask=True, loss_weight=1.0)),
+            dict(
+                type='HTCMaskHead',
+                num_convs=4,
+                in_channels=256,
+                conv_out_channels=256,
+                num_classes=80,
+                loss_mask=dict(
+                    type='CrossEntropyLoss', use_mask=True, loss_weight=1.0))
+        ],
+        semantic_roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=14, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[8]),
+        semantic_head=dict(
+            type='FusedSemanticHead',
+            num_ins=5,
+            fusion_level=1,
+            num_convs=4,
+            in_channels=256,
+            conv_out_channels=256,
+            num_classes=183,
+            ignore_label=255,
+            loss_weight=0.2)),
+
+    # model training and testing settings
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='RandomSampler',
+                num=256,
+                pos_fraction=0.5,
+                neg_pos_ub=-1,
+                add_gt_as_proposals=False),
+            allowed_border=0,
+            pos_weight=-1,
+            debug=False),
+        rpn_proposal=dict(
+            nms_pre=2000,
+            max_per_img=2000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=[
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.5,
+                    neg_iou_thr=0.5,
+                    min_pos_iou=0.5,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                mask_size=28,
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.6,
+                    neg_iou_thr=0.6,
+                    min_pos_iou=0.6,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                mask_size=28,
+                pos_weight=-1,
+                debug=False),
+            dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.7,
+                    neg_iou_thr=0.7,
+                    min_pos_iou=0.7,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                mask_size=28,
+                pos_weight=-1,
+                debug=False)
+        ]),
+    test_cfg=dict(
+        rpn=dict(
+            nms_pre=1000,
+            max_per_img=1000,
+            nms=dict(type='nms', iou_threshold=0.7),
+            min_bbox_size=0),
+        rcnn=dict(
+            score_thr=0.001,
+            nms=dict(type='nms', iou_threshold=0.5),
+            max_per_img=100,
+            mask_thr_binary=0.5)) 
+    )
+
+
 # dataset settings
 dataset_type = 'CocoDataset'
 data_root = 'data/coco/'
-img_norm_cfg = dict(mean=[123.675, 116.28, 103.53],
-                    std=[58.395, 57.12, 57.375],
-                    to_rgb=True)
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='LoadAnnotations', with_bbox=True, with_mask=True,
-         with_seg=True),
-    dict(type='Resize',
-         img_scale=[(1600, 400), (1600, 1400)],
-         multiscale_mode='range',
-         keep_ratio=True),
+    dict(
+        type='LoadAnnotations', with_bbox=True, with_mask=True, with_seg=True),
+    dict(
+        type='Resize',
+        img_scale=[(1600, 400), (1600, 1400)],
+        multiscale_mode='range',
+        keep_ratio=True),
     dict(type='RandomFlip', flip_ratio=0.5),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='Pad', size_divisor=32),
-    dict(type='SegResizeFlipPadRescale', scale_factor=1 / 8),
+    dict(type='SegRescale', scale_factor=1 / 8),
     dict(type='DefaultFormatBundle'),
-    dict(type='Collect',
-         keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks',
-               'gt_semantic_seg']),
+    dict(
+        type='Collect',
+        keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks', 'gt_semantic_seg']),
 ]
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='MultiScaleFlipAug',
-         img_scale=(1333, 800),
-         flip=False,
-         transforms=[
-             dict(type='Resize', keep_ratio=True),
-             dict(type='RandomFlip', flip_ratio=0.5),
-             dict(type='Normalize', **img_norm_cfg),
-             dict(type='Pad', size_divisor=32),
-             dict(type='ImageToTensor', keys=['img']),
-             dict(type='Collect', keys=['img']),
-         ])
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(1333, 800),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip', flip_ratio=0.5),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
 ]
 data = dict(
-    imgs_per_gpu=1,
+    samples_per_gpu=1,
     workers_per_gpu=1,
     train=dict(type=dataset_type,
                ann_file=data_root + 'annotations/instances_train2017.json',
                img_prefix=data_root + 'train2017/',
-               seg_prefix=data_root + 'stuffthingmaps/train2017/',
-               pipeline=train_pipeline),
+               pipeline=train_pipeline,
+               seg_prefix=data_root + 'stuffthingmaps/train2017/',),
     val=dict(type=dataset_type,
              ann_file=data_root + 'annotations/instances_val2017.json',
              img_prefix=data_root + 'val2017/',
@@ -243,15 +288,23 @@ data = dict(
               ann_file=data_root + 'annotations/instances_val2017.json',
               img_prefix=data_root + 'val2017/',
               pipeline=test_pipeline))
+evaluation = dict(metric=['bbox', 'segm'])
+
+# learning policy
 # optimizer
 optimizer = dict(type='SGD', lr=0.02, momentum=0.9, weight_decay=0.0001)
-optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
+optimizer_config = dict(grad_clip=None)
 # learning policy
-lr_config = dict(policy='step',
-                 warmup='linear',
-                 warmup_iters=500,
-                 warmup_ratio=1.0 / 3,
-                 step=[16, 19])
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=0.001,
+    step=[16, 19])
+runner = dict(type='EpochBasedRunner', max_epochs=20)
+
+
+# runtime
 checkpoint_config = dict(interval=1)
 # yapf:disable
 log_config = dict(
@@ -261,11 +314,10 @@ log_config = dict(
         # dict(type='TensorboardLoggerHook')
     ])
 # yapf:enable
-# runtime settings
-total_epochs = 20
+custom_hooks = [dict(type='NumClassCheckHook')]
+
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
-work_dir = './work_dirs/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]

--- a/configs/pose_estimation/pose_demo.yaml
+++ b/configs/pose_estimation/pose_demo.yaml
@@ -7,7 +7,7 @@ processor_cfg:
 
   detection_cfg:
     model_cfg: configs/mmdet/cascade_rcnn_r50_fpn_1x.py
-    checkpoint_file: mmskeleton://mmdet/cascade_rcnn_r50_fpn_20e
+    checkpoint_file: http://download.openmmlab.com/mmdetection/v2.0/cascade_rcnn/cascade_rcnn_r50_fpn_1x_coco/cascade_rcnn_r50_fpn_1x_coco_20200316-3dc56deb.pth
     bbox_thre: 0.8
   estimation_cfg:
     model_cfg: configs/pose_estimation/hrnet/pose_hrnet_w32_256x192_test.yaml

--- a/configs/pose_estimation/pose_demo_HD.yaml
+++ b/configs/pose_estimation/pose_demo_HD.yaml
@@ -7,7 +7,7 @@ processor_cfg:
 
   detection_cfg:
     model_cfg: configs/mmdet/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e.py
-    checkpoint_file: mmskeleton://mmdet/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e
+    checkpoint_file: http://download.openmmlab.com/mmdetection/v2.0/htc/htc_x101_64x4d_fpn_dconv_c3-c5_mstrain_400_1400_16x1_20e_coco/htc_x101_64x4d_fpn_dconv_c3-c5_mstrain_400_1400_16x1_20e_coco_20200312-946fd751.pth
     bbox_thre: 0.8
   estimation_cfg:
     model_cfg: configs/pose_estimation/hrnet/pose_hrnet_w32_256x192_test.yaml

--- a/configs/recognition/st_gcn_aaai18/kinetics-skeleton/train.yaml
+++ b/configs/recognition/st_gcn_aaai18/kinetics-skeleton/train.yaml
@@ -44,8 +44,8 @@ processor_cfg:
       # debug: true
 
   # dataloader setting
-  batch_size: 256
-  gpus: 4
+  batch_size: 64
+  gpus: -1
 
   # optimizer setting
   optimizer_cfg:
@@ -71,5 +71,6 @@ processor_cfg:
     checkpoint_config:
       interval: 5
     optimizer_config:
+      grad_clip:
   resume_from:
   load_from:

--- a/mmskeleton/datasets/coco.py
+++ b/mmskeleton/datasets/coco.py
@@ -18,7 +18,7 @@ import numpy as np
 from .estimation import EstiamtionDataset
 from ..ops.nms.nms import oks_nms
 from ..ops.nms.nms import soft_oks_nms
-from pycocotools import COCO, COCOeval
+from pycocotools import coco as COCO, cocoeval as COCOeval
 
 logger = logging.getLogger(__name__)
 

--- a/mmskeleton/datasets/skeleton/skeleton_process.py
+++ b/mmskeleton/datasets/skeleton/skeleton_process.py
@@ -1,6 +1,5 @@
 import random
 import numpy as np
-from mmskeleton.deprecated.datasets.utils import skeleton as skeleton_aaai18
 
 # def stgcn_aaai18_dataprocess(data,
 #                              window_size,

--- a/mmskeleton/utils/third_party.py
+++ b/mmskeleton/utils/third_party.py
@@ -1,10 +1,9 @@
 import lazy_import
 
 pycocotools = lazy_import.lazy_module("pycocotools")
-COCO = lazy_import.lazy_module("pycocotools.COCO")
-COCOeval = lazy_import.lazy_module("pycocotools.COCOeval")
+COCO = lazy_import.lazy_module("pycocotools.coco")
+COCOeval = lazy_import.lazy_module("pycocotools.cocoeval")
 mmdet = lazy_import.lazy_module("mmdet")
-lazy_import.lazy_module("mmdet.apis")
 
 
 def is_exist(module_name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cython
-torch>=1.8.1
-torchvision>=0.9.1
+torch>=1.6.0
+torchvision>=0.7.0
 pycocotools
 mmcv-full==1.3.3
 mmdet==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-mmcv
-torch>=1.1
-torchvision
+cython
+torch>=1.8.1
+torchvision>=0.9.1
+pycocotools
+mmcv-full==1.3.3
+mmdet==2.12.0
 lazy_import


### PR DESCRIPTION
It works with MMCV 1.3.3, and training `st_gcn_aaai18/kinetics-skeleton` (did not test other configs)

Regarding the loss function, latest mmcv does not propagate it, so I had to use a global variable

Thanks to #311 for the solution on training accuracy
Also includes #412 

Note: Might need to install `requirements.txt` twice, first with pytorch and pycocotools, then install mmcv and mmdet